### PR TITLE
Revised Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,36 +19,51 @@ jobs:
     name: Publish (${{ matrix.rid }})
     needs: build-test
     strategy:
+      fail-fast: false
       matrix:
         include:
           - rid: win-x64
-            ext: zip
+            os: windows-latest
+            exe: .exe
+            name: LincleLINK-win-x64.exe
           - rid: linux-x64
-            ext: tar.gz
-    runs-on: ubuntu-latest
+            os: ubuntu-latest
+            exe: ''
+            name: LincleLINK-linux-x64
+          - rid: osx-x64
+            os: macos-latest
+            exe: ''
+            name: LincleLINK-osx-x64
+          - rid: osx-arm64
+            os: macos-latest
+            exe: ''
+            name: LincleLINK-osx-arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
-      - name: Publish ${{ matrix.rid }}
-        run: dotnet publish src/LincleLINK.App -c Release -r ${{ matrix.rid }} --self-contained -o artifacts/publish/${{ matrix.rid }}
+      - name: Publish single-file
+        run: >-
+          dotnet publish src/LincleLINK.App -c Release -r ${{ matrix.rid }}
+          --self-contained -o artifacts/publish/${{ matrix.rid }}
+          -p:PublishSingleFile=true
+          -p:IncludeNativeLibrariesForSelfExtract=true
+          -p:DebugType=None
+          -p:DebugSymbols=false
+          -p:EnableCompressionInSingleFile=true
 
-      - name: Package
+      - name: Stage executable
         shell: bash
-        run: |
-          cd artifacts/publish
-          if [ "${{ matrix.ext }}" = "zip" ]; then
-            zip -r LincleLINK-${{ matrix.rid }}.zip ${{ matrix.rid }}
-          else
-            tar -czf LincleLINK-${{ matrix.rid }}.tar.gz ${{ matrix.rid }}
-          fi
+        run: cp artifacts/publish/${{ matrix.rid }}/LincleLINK${{ matrix.exe }} artifacts/publish/${{ matrix.name }}
 
       - uses: actions/upload-artifact@v5
         with:
-          name: LincleLINK-${{ matrix.rid }}
-          path: artifacts/publish/LincleLINK-${{ matrix.rid }}.${{ matrix.ext }}
+          name: ${{ matrix.name }}
+          path: artifacts/publish/${{ matrix.name }}
+          if-no-files-found: error
 
   attach:
     name: Attach to release

--- a/docs/plan/11-ci.md
+++ b/docs/plan/11-ci.md
@@ -51,15 +51,20 @@ Notes:
 
 ## 5. `release.yml` — per-OS publish (M6)
 
-Manual `workflow_dispatch`. Builds + tests once (reuse `ci.yml` steps or a shared job), then:
+Manual `workflow_dispatch`. Builds + tests once, then publishes a **single-file, self-contained** executable per RID on its native runner:
 
-- `dotnet publish src/LincleLINK.App -c Release -r win-x64 --self-contained` → zip
-- `dotnet publish src/LincleLINK.App -c Release -r linux-x64 --self-contained` → tar.gz
-- Attach both to a GitHub Release (tag from `Directory.Build.props` `Version`).
+- `dotnet publish src/LincleLINK.App -c Release -r <rid> --self-contained -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:DebugSymbols=false -p:EnableCompressionInSingleFile=true`
+- RID matrix (native `runs-on`, `fail-fast: false`):
+  - `win-x64` on `windows-latest` → `LincleLINK-win-x64.exe`
+  - `linux-x64` on `ubuntu-latest` → `LincleLINK-linux-x64`
+  - `osx-x64` and `osx-arm64` on `macos-latest` → `LincleLINK-osx-x64`, `LincleLINK-osx-arm64`
+- Each single executable is renamed per RID and uploaded directly (no zip/tar.gz wrapper); the `attach` job uploads them all to a GitHub Release (tag from `Directory.Build.props` `Version`).
 
 Notes:
 
-- Self-contained avoids requiring the user to install the .NET runtime on either OS.
+- `IncludeNativeLibrariesForSelfExtract` is required so Avalonia's native Skia libs self-extract at runtime on Linux/macOS.
+- `DebugType=None`/`DebugSymbols=false` drop PDBs from the publish output; PDBs are not part of the release.
+- Self-contained avoids requiring the user to install the .NET runtime on any OS.
 - Semi.Avalonia/DataGrid publish cleanly (no trimming needed; trimming out of scope).
 - Icon/version metadata: `app.manifest` (Windows DPI) + `LL_logo.ico` carried into the App project (`01` §6).
 - Publishing is M6 polish, not a prerequisite for feature work.
@@ -67,4 +72,4 @@ Notes:
 ## 6. Decisions (locked)
 
 - **D1** Coverage threshold is a soft target + report at M0; harden to a gate at M6.
-- **D2** Release publish is self-contained `win-x64` + `linux-x64`, manual `workflow_dispatch`, wired at M6.
+- **D2** Release publish is single-file self-contained `win-x64` + `linux-x64` + `osx-x64` + `osx-arm64` (no PDBs), manual `workflow_dispatch`, wired at M6.


### PR DESCRIPTION
Adds matrix build options for Mac OSX x64 and arm64. Produces single file artifacts for each of the builds.