### PR TITLE
Global exception handling and error report window (issue #16)

### DIFF
--- a/src/LincleLINK.App/Abstractions/IExceptionReporter.cs
+++ b/src/LincleLINK.App/Abstractions/IExceptionReporter.cs
@@ -1,0 +1,13 @@
+namespace LincleLINK.App.Abstractions;
+
+/// <summary>
+/// Routes unexpected exceptions to the global error-report surface (issue #16).
+/// Implemented by <c>GlobalExceptionHandler</c>; consumed by operation hosts that
+/// catch an exception before it would reach the dispatcher hooks, so the report
+/// window still gets the full stack trace.
+/// </summary>
+public interface IExceptionReporter
+{
+    /// <summary>Presents an unexpected exception as a recoverable error report.</summary>
+    void ReportUnexpected(Exception exception);
+}

--- a/src/LincleLINK.App/App.axaml
+++ b/src/LincleLINK.App/App.axaml
@@ -25,6 +25,7 @@
                     <SolidColorBrush x:Key="LLAccentText" Color="#B57B00" />
                     <SolidColorBrush x:Key="LLWarning" Color="#A66A00" />
                     <SolidColorBrush x:Key="LLDanger" Color="#C04A3A" />
+                    <SolidColorBrush x:Key="LLDangerSoft" Color="#F7E2DE" />
                     <SolidColorBrush x:Key="LLSuccess" Color="#2E8B57" />
                     <SolidColorBrush x:Key="LLVeil" Color="#59000000" />
                 </ResourceDictionary>
@@ -37,6 +38,7 @@
                     <SolidColorBrush x:Key="LLAccentText" Color="#FFCF5C" />
                     <SolidColorBrush x:Key="LLWarning" Color="#FFCF5C" />
                     <SolidColorBrush x:Key="LLDanger" Color="#FF8A75" />
+                    <SolidColorBrush x:Key="LLDangerSoft" Color="#3A2622" />
                     <SolidColorBrush x:Key="LLSuccess" Color="#5FC78A" />
                     <SolidColorBrush x:Key="LLVeil" Color="#8C000000" />
                 </ResourceDictionary>

--- a/src/LincleLINK.App/App.axaml.cs
+++ b/src/LincleLINK.App/App.axaml.cs
@@ -6,7 +6,6 @@ using LincleLINK.App.Composition;
 using LincleLINK.App.Services;
 using LincleLINK.App.ViewModels;
 using LincleLINK.App.Views;
-using LincleLINK.Core.Abstractions.Dialogs;
 using LincleLINK.Core.Abstractions.Settings;
 using LincleLINK.Core.Application;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,6 +17,7 @@ namespace LincleLINK.App;
 public partial class App : Application
 {
     private ServiceProvider? _services;
+    private GlobalExceptionHandler? _exceptionHandler;
 
     public override void Initialize()
     {
@@ -29,11 +29,18 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
+            // Install the global exception handler before the bootstrapper runs so
+            // even composition-root failures route through it (issue #16 D1). It
+            // takes no DI dependencies; only the window/quit providers.
+            _exceptionHandler = new GlobalExceptionHandler(
+                () => desktop.MainWindow, () => desktop.Shutdown(1));
+            _exceptionHandler.Install();
+
             try
             {
                 desktop.MainWindow = new MainWindow();
 
-                _services = await AppBootstrapper.BuildAsync(() => desktop.MainWindow);
+                _services = await AppBootstrapper.BuildAsync(() => desktop.MainWindow, _exceptionHandler);
                 var logger = _services.GetRequiredService<ILogger<App>>();
                 logger.LogInformation("Bootstrap completed; starting the main window");
 
@@ -115,22 +122,19 @@ public partial class App : Application
     private async Task ReportStartupFailureAsync(
         IClassicDesktopStyleApplicationLifetime desktop, Exception ex)
     {
-        if (_services is { } services)
+        // The report window in fatal mode carries the full stack trace instead of
+        // a one-line message dialog (issue #16 D5); it completes when the user
+        // closes it (Quit / X / Esc), then the process shuts down cleanly.
+        if (_exceptionHandler is { } handler)
         {
             try
             {
-                if (desktop.MainWindow is { IsVisible: false } mainWindow)
-                {
-                    mainWindow.Show();
-                }
-
-                var dialogs = services.GetRequiredService<IDialogService>();
-                await dialogs.ErrorAsync($"LincleLINK could not start:\n\n{ex.Message}", "Startup failed");
+                await handler.PresentFatalAsync(ex);
             }
             catch
             {
-                // No UI to report through (dialog infrastructure not ready yet);
-                // the console line above remains the record.
+                // No UI to report through (dispatcher not available); the console
+                // line above remains the record.
             }
         }
 

--- a/src/LincleLINK.App/App.axaml.cs
+++ b/src/LincleLINK.App/App.axaml.cs
@@ -23,6 +23,7 @@ public partial class App : Application
     {
         AvaloniaXamlLoader.Load(this);
         BrandTheme.Apply(this);
+        SemiLocale.Apply(this);
     }
 
     public override async void OnFrameworkInitializationCompleted()

--- a/src/LincleLINK.App/Composition/AppBootstrapper.cs
+++ b/src/LincleLINK.App/Composition/AppBootstrapper.cs
@@ -19,7 +19,9 @@ namespace LincleLINK.App.Composition;
 
 public static class AppBootstrapper
 {
-    public static async Task<ServiceProvider> BuildAsync(Func<Window?> ownerProvider)
+    public static async Task<ServiceProvider> BuildAsync(
+        Func<Window?> ownerProvider,
+        GlobalExceptionHandler exceptionHandler)
     {
         var settingsFile = AppConfig.SettingsFile;
 
@@ -74,6 +76,12 @@ public static class AppBootstrapper
         services.AddLincleLINKCore();
         services.AddSingleton<IAppPaths>(paths);
         services.AddSingleton<LogoCatalog>();
+
+        // The global exception handler is created once by App before the
+        // bootstrapper runs (so bootstrap failures still route through it) and is
+        // shared here so operation hosts can hand exceptions to the report window.
+        services.AddSingleton(exceptionHandler);
+        services.AddSingleton<IExceptionReporter>(exceptionHandler);
 
         RegisterSharedServices(services, settingsFile, ownerProvider);
 

--- a/src/LincleLINK.App/Services/ExceptionAccumulator.cs
+++ b/src/LincleLINK.App/Services/ExceptionAccumulator.cs
@@ -36,6 +36,10 @@ public sealed class ExceptionAccumulator
 
     public bool HasOverflow => _overflowCount > 0;
 
+    /// <summary>The overflow line, singular for exactly one dropped error.</summary>
+    public static string FormatOverflow(int count)
+        => count == 1 ? "…and 1 more distinct error" : $"…and {count} more distinct errors";
+
     public void Reset()
     {
         _items.Clear();
@@ -92,7 +96,7 @@ public sealed class ExceptionAccumulator
         if (HasOverflow)
         {
             sb.AppendLine();
-            sb.AppendLine($"…and {OverflowCount} more distinct errors (the {MaxDistinctExceptions}-exception cap was reached - further exceptions were dropped)");
+            sb.AppendLine($"{FormatOverflow(OverflowCount)} (the {MaxDistinctExceptions}-exception cap was reached - further exceptions were dropped)");
         }
 
         return sb.ToString().TrimEnd();

--- a/src/LincleLINK.App/Services/ExceptionAccumulator.cs
+++ b/src/LincleLINK.App/Services/ExceptionAccumulator.cs
@@ -44,7 +44,7 @@ public sealed class ExceptionAccumulator
 
     /// <summary>
     /// Registers another occurrence. Returns false when it was dropped for hitting
-    /// the cap (the overflow counter still grows) so callers can skip a UI refresh.
+    /// the cap (the overflow counter still grows).
     /// </summary>
     public bool Add(Exception exception)
     {
@@ -92,7 +92,7 @@ public sealed class ExceptionAccumulator
         if (HasOverflow)
         {
             sb.AppendLine();
-            sb.AppendLine($"…and {OverflowCount} more distinct errors (the {MaxDistinctExceptions}-exception cap was reached - copy the report for the full list)");
+            sb.AppendLine($"…and {OverflowCount} more distinct errors (the {MaxDistinctExceptions}-exception cap was reached - further exceptions were dropped)");
         }
 
         return sb.ToString().TrimEnd();

--- a/src/LincleLINK.App/Services/ExceptionAccumulator.cs
+++ b/src/LincleLINK.App/Services/ExceptionAccumulator.cs
@@ -1,0 +1,112 @@
+namespace LincleLINK.App.Services;
+
+/// <summary>
+/// Storm and re-entrancy protection for the error-report window (issue #16 D4).
+/// Plain and UI-free so the dedupe/cap logic is unit-testable. An exception is
+/// identified by its type + message + top stack frame: an identical repeat bumps
+/// the primary occurrence count, a different one becomes an additional section,
+/// and past <see cref="MaxDistinctExceptions"/> only an overflow counter grows.
+/// </summary>
+public sealed class ExceptionAccumulator
+{
+    /// <summary>At most this many distinct exceptions accumulate per report window.</summary>
+    public const int MaxDistinctExceptions = 10;
+
+    private sealed record Accumulated(Exception Exception, string Key)
+    {
+        public int Count { get; set; } = 1;
+    }
+
+    private readonly List<Accumulated> _items = [];
+    private int _overflowCount;
+
+    public ExceptionAccumulator()
+    {
+    }
+
+    /// <summary>The first (headline) exception; null before any add.</summary>
+    public Exception? Primary => _items.Count > 0 ? _items[0].Exception : null;
+
+    /// <summary>How many times the primary exception occurred (drives the "×N" badge).</summary>
+    public int PrimaryOccurrences => _items.Count > 0 ? _items[0].Count : 0;
+
+    public int DistinctCount => _items.Count;
+
+    public int OverflowCount => _overflowCount;
+
+    public bool HasOverflow => _overflowCount > 0;
+
+    public void Reset()
+    {
+        _items.Clear();
+        _overflowCount = 0;
+    }
+
+    /// <summary>
+    /// Registers another occurrence. Returns false when it was dropped for hitting
+    /// the cap (the overflow counter still grows) so callers can skip a UI refresh.
+    /// </summary>
+    public bool Add(Exception exception)
+    {
+        var key = BuildKey(exception);
+        var existing = _items.FirstOrDefault(item => item.Key == key);
+        if (existing is not null)
+        {
+            existing.Count++;
+            return true;
+        }
+
+        if (_items.Count >= MaxDistinctExceptions)
+        {
+            _overflowCount++;
+            return false;
+        }
+
+        _items.Add(new Accumulated(exception, key));
+        return true;
+    }
+
+    /// <summary>All distinct exceptions except the primary, for the appended sections.</summary>
+    public IEnumerable<Exception> AdditionalExceptions() => _items.Skip(1).Select(item => item.Exception);
+
+    /// <summary>
+    /// The details text shown in the report window: the primary trace, then an
+    /// "Also occurred" section per additional distinct exception, then the
+    /// overflow line when the cap was reached.
+    /// </summary>
+    public string BuildDetailsText()
+    {
+        var sb = new System.Text.StringBuilder();
+        if (Primary is not null)
+        {
+            sb.AppendLine(Primary.ToString());
+        }
+
+        foreach (var extra in AdditionalExceptions())
+        {
+            sb.AppendLine();
+            sb.AppendLine("─ Also occurred ─");
+            sb.AppendLine(extra.ToString());
+        }
+
+        if (HasOverflow)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"…and {OverflowCount} more distinct errors (the {MaxDistinctExceptions}-exception cap was reached - copy the report for the full list)");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// Dedupe key for one exception: type + message + top stack frame. The frame
+    /// anchors the identity to where the throw happened, not just its text.
+    /// </summary>
+    public static string BuildKey(Exception exception)
+    {
+        var frame = exception.StackTrace?
+            .Split('\n')
+            .FirstOrDefault(line => !string.IsNullOrWhiteSpace(line))?.Trim();
+        return $"{exception.GetType().FullName}|{exception.Message}|{frame}";
+    }
+}

--- a/src/LincleLINK.App/Services/ExceptionReport.cs
+++ b/src/LincleLINK.App/Services/ExceptionReport.cs
@@ -1,0 +1,66 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using Avalonia;
+
+namespace LincleLINK.App.Services;
+
+/// <summary>
+/// Pure Markdown formatter for the error-report window (issue #16 D3). Static and
+/// side-effect-free so it is unit-testable and reusable by the fatal path's
+/// console fallback. The output is a GitHub-issue-ready block: a "What I was
+/// doing" placeholder prompts the reporter, and the fenced exception keeps long
+/// stack traces collapsed.
+/// </summary>
+public static class ExceptionReport
+{
+    /// <summary>
+    /// The values shown in the report window's environment strip; the same values
+    /// that go into the Markdown report so the two never drift apart.
+    /// </summary>
+    public static string EnvironmentLine =>
+        $"LincleLINK {EntryVersion()} · {RuntimeInformation.OSDescription} ({RuntimeInformation.OSArchitecture}) · {RuntimeInformation.FrameworkDescription} · Avalonia {AvaloniaVersion()}";
+
+    public static string Format(Exception exception, DateTimeOffset utcNow, int occurrences)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("### Crash report");
+        sb.AppendLine();
+        sb.AppendLine($"- **Version:** {EntryVersion()}");
+        sb.AppendLine($"- **OS:** {RuntimeInformation.OSDescription} ({RuntimeInformation.OSArchitecture})");
+        sb.AppendLine($"- **Runtime:** {RuntimeInformation.FrameworkDescription} · Avalonia {AvaloniaVersion()}");
+        sb.AppendLine($"- **When (UTC):** {utcNow:yyyy-MM-dd HH:mm:ss}");
+        sb.AppendLine($"- **Occurrences:** {occurrences}");
+        sb.AppendLine();
+        sb.AppendLine("**What I was doing:**");
+        sb.AppendLine();
+        sb.AppendLine();
+        sb.AppendLine("```");
+        sb.AppendLine(exception.ToString());
+        sb.AppendLine("```");
+        return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>Informational version of the entry assembly, without the build metadata suffix.</summary>
+    private static string EntryVersion()
+    {
+        var assembly = Assembly.GetEntryAssembly();
+        var informational = assembly?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (!string.IsNullOrEmpty(informational))
+        {
+            var plus = informational.IndexOf('+');
+            return plus > 0 ? informational[..plus] : informational;
+        }
+
+        return assembly?.GetName().Version?.ToString(3) ?? "unknown";
+    }
+
+    private static string AvaloniaVersion()
+    {
+        var assembly = typeof(Application).Assembly;
+        var informational = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        return string.IsNullOrEmpty(informational)
+            ? assembly.GetName().Version?.ToString(3) ?? "unknown"
+            : informational;
+    }
+}

--- a/src/LincleLINK.App/Services/GlobalExceptionHandler.cs
+++ b/src/LincleLINK.App/Services/GlobalExceptionHandler.cs
@@ -41,6 +41,10 @@ public sealed class GlobalExceptionHandler : IExceptionReporter
     private Window? _window;
     private readonly List<TaskCompletionSource> _pendingCloseSignals = [];
     private bool _installed;
+
+    // Set by fatal presentation methods before the VM exists so Present() knows to
+    // open a fatal window. Intentionally never reset on timeout paths because every
+    // caller (ReportStartupFailureAsync, AppDomain hook) terminates the process after.
     private bool _isFatal;
 
     public GlobalExceptionHandler(Func<Window?> ownerProvider, Action quit)
@@ -171,6 +175,12 @@ public sealed class GlobalExceptionHandler : IExceptionReporter
 
     private void OnDispatcherUnhandledException(object? sender, DispatcherUnhandledExceptionEventArgs e)
     {
+        if (e.Exception is OutOfMemoryException or StackOverflowException)
+        {
+            // Unrecoverable: let the process terminate naturally.
+            return;
+        }
+
         // Recoverable: marking the exception handled keeps the dispatcher loop running.
         e.Handled = true;
         Present(e.Exception);
@@ -287,6 +297,8 @@ public sealed class GlobalExceptionHandler : IExceptionReporter
             {
                 _quit();
             }
+
+            _isFatal = false;
 
             foreach (var signal in _pendingCloseSignals)
             {

--- a/src/LincleLINK.App/Services/GlobalExceptionHandler.cs
+++ b/src/LincleLINK.App/Services/GlobalExceptionHandler.cs
@@ -1,0 +1,246 @@
+using Avalonia.Controls;
+using Avalonia.Platform;
+using Avalonia.Threading;
+using LincleLINK.App.Abstractions;
+using LincleLINK.App.ViewModels;
+
+namespace LincleLINK.App.Services;
+
+/// <summary>
+/// Owns the process-global exception hooks and the error-report window
+/// (issue #16 D1/D2). Created and installed at the top of
+/// <c>App.OnFrameworkInitializationCompleted</c>, before the composition root
+/// runs, so even bootstrap failures route through it; it deliberately takes no DI
+/// dependencies, only the owner/window provider and the quit action. Every
+/// presentation path is wrapped and must never throw, with <c>Console.Error</c>
+/// as the terminal fallback.
+/// </summary>
+public sealed class GlobalExceptionHandler : IExceptionReporter
+{
+    private static readonly WindowIcon AppIcon =
+        new(AssetLoader.Open(new Uri("avares://LincleLINK/Assets/LL_logo.ico")));
+
+    private readonly Func<Window?> _ownerProvider;
+    private readonly Action _quit;
+
+    private ExceptionReportViewModel? _reportVm;
+    private bool _installed;
+    private bool _isFatal;
+
+    public GlobalExceptionHandler(Func<Window?> ownerProvider, Action quit)
+    {
+        _ownerProvider = ownerProvider;
+        _quit = quit;
+    }
+
+    /// <summary>Registers the process-global hooks. Safe to call more than once.</summary>
+    public void Install()
+    {
+        if (_installed)
+        {
+            return;
+        }
+
+        _installed = true;
+        Dispatcher.UIThread.UnhandledException += OnDispatcherUnhandledException;
+        TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+        AppDomain.CurrentDomain.UnhandledException += OnAppDomainUnhandledException;
+    }
+
+    public void ReportUnexpected(Exception exception) => Present(exception);
+
+    /// <summary>
+    /// Presents the report window in fatal mode and completes when the window is
+    /// closed (callers then shut the process down). If no UI can be shown it falls
+    /// back to <c>Console.Error</c> with the full formatted report.
+    /// </summary>
+    public Task PresentFatalAsync(Exception exception)
+    {
+        _isFatal = true;
+        var closed = new TaskCompletionSource();
+
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            Present(exception, closed);
+        }
+        else
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                try
+                {
+                    Present(exception, closed);
+                }
+                catch (Exception ex)
+                {
+                    closed.TrySetException(ex);
+                }
+            });
+        }
+
+        return closed.Task;
+    }
+
+    /// <summary>
+    /// Best-effort fatal presentation from a non-UI thread (AppDomain hook, where
+    /// the process is already doomed). Blocks briefly to give the window a chance
+    /// to appear; the <c>Console.Error</c> dump is the record when the dispatcher
+    /// is gone.
+    /// </summary>
+    public void PresentFatal(Exception exception)
+    {
+        _isFatal = true;
+        try
+        {
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                Present(exception);
+                return;
+            }
+
+            var closed = new TaskCompletionSource();
+            Dispatcher.UIThread.Post(() =>
+            {
+                try
+                {
+                    Present(exception, closed);
+                }
+                catch (Exception ex)
+                {
+                    closed.TrySetException(ex);
+                }
+            });
+
+            closed.Task.Wait(TimeSpan.FromSeconds(2));
+        }
+        catch
+        {
+            Console.Error.WriteLine(ExceptionReport.Format(exception, DateTimeOffset.UtcNow, 1));
+        }
+    }
+
+    private void OnDispatcherUnhandledException(object? sender, DispatcherUnhandledExceptionEventArgs e)
+    {
+        // Recoverable: marking the exception handled keeps the dispatcher loop running.
+        e.Handled = true;
+        Present(e.Exception);
+    }
+
+    private void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+    {
+        e.SetObserved();
+        if (e.Exception is not { } aggregate)
+        {
+            return;
+        }
+
+        // Unwrap the single common case (one fire-and-forget task faulting).
+        var exception = aggregate.InnerExceptions.Count == 1
+            ? aggregate.InnerExceptions[0]
+            : aggregate;
+
+        // GC-timing-dependent, so this is the safety net, not the primary path;
+        // marshal to the UI thread so the window is only touched there.
+        Dispatcher.UIThread.Post(() => Present(exception));
+    }
+
+    private void OnAppDomainUnhandledException(object? sender, UnhandledExceptionEventArgs e)
+    {
+        if (e.ExceptionObject is Exception exception)
+        {
+            PresentFatal(exception);
+        }
+    }
+
+    private void Present(Exception exception, TaskCompletionSource? closeSignal = null)
+    {
+        try
+        {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Post(() => Present(exception, closeSignal));
+                return;
+            }
+
+            // One window at a time: while a report is open, further exceptions
+            // accumulate into it instead of spawning new windows (D4). A caller
+            // waiting on a close signal (fatal mode) is released immediately when
+            // the existing window already covers the report.
+            if (_reportVm is not null)
+            {
+                _reportVm.AddException(exception);
+                closeSignal?.TrySetResult();
+                return;
+            }
+
+            ShowWindow(exception, closeSignal);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("Could not show the error report: " + ex);
+        }
+    }
+
+    private void ShowWindow(Exception exception, TaskCompletionSource? closeSignal)
+    {
+        var vm = new ExceptionReportViewModel(exception, _isFatal, _quit);
+        var window = new Window
+        {
+            Title = vm.Title,
+            Content = vm,
+            Width = vm.DialogSize.Width,
+            Height = vm.DialogSize.Height,
+            MinWidth = vm.DialogMinSize.Width,
+            MinHeight = vm.DialogMinSize.Height,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = true,
+            Icon = AppIcon,
+        };
+        ThemeManager.ApplyTitleBar(window);
+        vm.AttachWindow(window);
+
+        window.Closed += (_, _) =>
+        {
+            // In fatal mode closing the window by any means (Quit, X, Esc) quits;
+            // recoverable mode only reports, so a close is just a dismiss.
+            if (_isFatal)
+            {
+                _quit();
+            }
+
+            closeSignal?.TrySetResult();
+            _reportVm = null;
+        };
+
+        _reportVm = vm;
+
+        var owner = _ownerProvider();
+        if (owner is not null)
+        {
+            if (!owner.IsVisible)
+            {
+                owner.Show();
+            }
+
+            // Fire-and-forget, but internally catching: a failure to host must
+            // never surface as an unobserved task exception from inside the handler.
+            _ = ShowDialogGuardedAsync(owner, window);
+        }
+        else
+        {
+            window.Show();
+        }
+    }
+
+    private static async Task ShowDialogGuardedAsync(Window owner, Window window)
+    {
+        try
+        {
+            await window.ShowDialog(owner);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("Could not show the error report window: " + ex);
+        }
+    }
+}

--- a/src/LincleLINK.App/Services/GlobalExceptionHandler.cs
+++ b/src/LincleLINK.App/Services/GlobalExceptionHandler.cs
@@ -51,17 +51,19 @@ public sealed class GlobalExceptionHandler : IExceptionReporter
 
     /// <summary>
     /// Presents the report window in fatal mode and completes when the window is
-    /// closed (callers then shut the process down). If no UI can be shown it falls
-    /// back to <c>Console.Error</c> with the full formatted report.
+    /// closed (callers then shut the process down). If no window appears within a
+    /// short grace period it falls back to <c>Console.Error</c> with the full
+    /// formatted report.
     /// </summary>
     public Task PresentFatalAsync(Exception exception)
     {
         _isFatal = true;
         var closed = new TaskCompletionSource();
+        var shown = new TaskCompletionSource();
 
         if (Dispatcher.UIThread.CheckAccess())
         {
-            Present(exception, closed);
+            Present(exception, closed, shown);
         }
         else
         {
@@ -69,23 +71,25 @@ public sealed class GlobalExceptionHandler : IExceptionReporter
             {
                 try
                 {
-                    Present(exception, closed);
+                    Present(exception, closed, shown);
                 }
                 catch (Exception ex)
                 {
                     closed.TrySetException(ex);
+                    shown.TrySetException(ex);
                 }
             });
         }
 
-        return closed.Task;
+        return AwaitFatalPresentationAsync(exception, shown, closed);
     }
 
     /// <summary>
     /// Best-effort fatal presentation from a non-UI thread (AppDomain hook, where
-    /// the process is already doomed). Blocks briefly to give the window a chance
-    /// to appear; the <c>Console.Error</c> dump is the record when the dispatcher
-    /// is gone.
+    /// the process is already doomed). Waits a short time for the window to appear;
+    /// once shown it blocks until the window closes so the report stays readable
+    /// instead of the CLR terminating the app under it. The <c>Console.Error</c>
+    /// dump is the record when no window can be shown.
     /// </summary>
     public void PresentFatal(Exception exception)
     {
@@ -99,29 +103,54 @@ public sealed class GlobalExceptionHandler : IExceptionReporter
             }
 
             var closed = new TaskCompletionSource();
+            var shown = new TaskCompletionSource();
             Dispatcher.UIThread.Post(() =>
             {
                 try
                 {
-                    Present(exception, closed);
+                    Present(exception, closed, shown);
                 }
                 catch (Exception ex)
                 {
                     closed.TrySetException(ex);
+                    shown.TrySetException(ex);
                 }
             });
 
-            if (!closed.Task.Wait(TimeSpan.FromSeconds(2)))
+            if (!shown.Task.Wait(TimeSpan.FromSeconds(2)))
             {
-                // The dispatcher never ran the callback (or the window is still up
-                // while the process is dying): dump the full report as the record.
+                // The dispatcher never showed a window (or the pump is gone):
+                // dump the full report as the record.
                 Console.Error.WriteLine(ExceptionReport.Format(exception, DateTimeOffset.UtcNow, 1));
+                return;
             }
+
+            // Shown: keep the crashing thread blocked until the window closes.
+            closed.Task.Wait();
         }
         catch
         {
             Console.Error.WriteLine(ExceptionReport.Format(exception, DateTimeOffset.UtcNow, 1));
         }
+    }
+
+    private static async Task AwaitFatalPresentationAsync(
+        Exception exception, TaskCompletionSource shown, TaskCompletionSource closed)
+    {
+        try
+        {
+            await shown.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        }
+        catch (TimeoutException)
+        {
+            // No window came up (dispatcher gone or never pumped): the console
+            // report is the record.
+            Console.Error.WriteLine(ExceptionReport.Format(exception, DateTimeOffset.UtcNow, 1));
+            return;
+        }
+
+        // Shown: block until the window closes so the report stays readable.
+        await closed.Task;
     }
 
     private void OnDispatcherUnhandledException(object? sender, DispatcherUnhandledExceptionEventArgs e)
@@ -157,13 +186,13 @@ public sealed class GlobalExceptionHandler : IExceptionReporter
         }
     }
 
-    private void Present(Exception exception, TaskCompletionSource? closeSignal = null)
+    private void Present(Exception exception, TaskCompletionSource? closeSignal = null, TaskCompletionSource? shownSignal = null)
     {
         try
         {
             if (!Dispatcher.UIThread.CheckAccess())
             {
-                Dispatcher.UIThread.Post(() => Present(exception, closeSignal));
+                Dispatcher.UIThread.Post(() => Present(exception, closeSignal, shownSignal));
                 return;
             }
 
@@ -178,15 +207,17 @@ public sealed class GlobalExceptionHandler : IExceptionReporter
                 return;
             }
 
-            ShowWindow(exception, closeSignal);
+            ShowWindow(exception, closeSignal, shownSignal);
         }
         catch (Exception ex)
         {
             Console.Error.WriteLine("Could not show the error report: " + ex);
+            closeSignal?.TrySetException(ex);
+            shownSignal?.TrySetException(ex);
         }
     }
 
-    private void ShowWindow(Exception exception, TaskCompletionSource? closeSignal)
+    private void ShowWindow(Exception exception, TaskCompletionSource? closeSignal, TaskCompletionSource? shownSignal)
     {
         var vm = new ExceptionReportViewModel(exception, _isFatal, _quit);
         var window = new Window
@@ -207,6 +238,8 @@ public sealed class GlobalExceptionHandler : IExceptionReporter
         // Continue (and Esc, its IsCancel binding) ask the view model to close;
         // close the window on CloseRequested, mirroring the DialogService pattern.
         vm.CloseRequested += (_, _) => window.Close();
+
+        window.Opened += (_, _) => shownSignal?.TrySetResult();
 
         window.Closed += (_, _) =>
         {

--- a/src/LincleLINK.App/Services/GlobalExceptionHandler.cs
+++ b/src/LincleLINK.App/Services/GlobalExceptionHandler.cs
@@ -24,6 +24,8 @@ public sealed class GlobalExceptionHandler : IExceptionReporter
     private readonly Action _quit;
 
     private ExceptionReportViewModel? _reportVm;
+    private Window? _window;
+    private readonly List<TaskCompletionSource> _pendingCloseSignals = [];
     private bool _installed;
     private bool _isFatal;
 
@@ -197,13 +199,29 @@ public sealed class GlobalExceptionHandler : IExceptionReporter
             }
 
             // One window at a time: while a report is open, further exceptions
-            // accumulate into it instead of spawning new windows (D4). A caller
-            // waiting on a close signal (fatal mode) is released immediately when
-            // the existing window already covers the report.
+            // accumulate into it instead of spawning new windows (D4). A fatal
+            // caller arriving while a recoverable report is open upgrades that
+            // window so the messaging and quit-on-close match, then stays blocked
+            // on its close signal until the window actually closes.
             if (_reportVm is not null)
             {
+                if (_isFatal && !_reportVm.IsFatal)
+                {
+                    _reportVm.MakeFatal();
+                    if (_window is not null)
+                    {
+                        _window.Title = _reportVm.Title;
+                    }
+                }
+
                 _reportVm.AddException(exception);
-                closeSignal?.TrySetResult();
+
+                if (closeSignal is not null)
+                {
+                    _pendingCloseSignals.Add(closeSignal);
+                }
+
+                shownSignal?.TrySetResult();
                 return;
             }
 
@@ -241,20 +259,41 @@ public sealed class GlobalExceptionHandler : IExceptionReporter
 
         window.Opened += (_, _) => shownSignal?.TrySetResult();
 
+        if (closeSignal is not null)
+        {
+            _pendingCloseSignals.Add(closeSignal);
+        }
+
         window.Closed += (_, _) =>
         {
-            // In fatal mode closing the window by any means (Quit, X, Esc) quits;
-            // recoverable mode only reports, so a close is just a dismiss.
-            if (_isFatal)
+            // Closing the window by any means (Quit, X, Esc) quits only when this
+            // window is fatal - fatality is per-window, so a report upgraded by
+            // MakeFatal quits even though it opened in recoverable mode.
+            if (vm.IsFatal)
             {
                 _quit();
             }
 
-            closeSignal?.TrySetResult();
-            _reportVm = null;
+            foreach (var signal in _pendingCloseSignals)
+            {
+                signal.TrySetResult();
+            }
+
+            _pendingCloseSignals.Clear();
+
+            if (ReferenceEquals(_reportVm, vm))
+            {
+                _reportVm = null;
+            }
+
+            if (ReferenceEquals(_window, window))
+            {
+                _window = null;
+            }
         };
 
         _reportVm = vm;
+        _window = window;
 
         var owner = _ownerProvider();
         if (owner is not null)

--- a/src/LincleLINK.App/Services/GlobalExceptionHandler.cs
+++ b/src/LincleLINK.App/Services/GlobalExceptionHandler.cs
@@ -17,8 +17,22 @@ namespace LincleLINK.App.Services;
 /// </summary>
 public sealed class GlobalExceptionHandler : IExceptionReporter
 {
-    private static readonly WindowIcon AppIcon =
-        new(AssetLoader.Open(new Uri("avares://LincleLINK/Assets/LL_logo.ico")));
+    // Loaded lazily and guarded: this handler is installed before anything else
+    // runs, so a failure here must never throw at type-init and prevent the hooks
+    // from ever being registered. A null icon is acceptable (Window.Icon is nullable).
+    private static readonly Lazy<WindowIcon?> AppIcon = new(TryLoadAppIcon);
+
+    private static WindowIcon? TryLoadAppIcon()
+    {
+        try
+        {
+            return new WindowIcon(AssetLoader.Open(new Uri("avares://LincleLINK/Assets/LL_logo.ico")));
+        }
+        catch
+        {
+            return null;
+        }
+    }
 
     private readonly Func<Window?> _ownerProvider;
     private readonly Action _quit;
@@ -248,7 +262,7 @@ public sealed class GlobalExceptionHandler : IExceptionReporter
             MinHeight = vm.DialogMinSize.Height,
             WindowStartupLocation = WindowStartupLocation.CenterOwner,
             CanResize = true,
-            Icon = AppIcon,
+            Icon = AppIcon.Value,
         };
         ThemeManager.ApplyTitleBar(window);
         vm.AttachWindow(window);

--- a/src/LincleLINK.App/Services/GlobalExceptionHandler.cs
+++ b/src/LincleLINK.App/Services/GlobalExceptionHandler.cs
@@ -111,7 +111,12 @@ public sealed class GlobalExceptionHandler : IExceptionReporter
                 }
             });
 
-            closed.Task.Wait(TimeSpan.FromSeconds(2));
+            if (!closed.Task.Wait(TimeSpan.FromSeconds(2)))
+            {
+                // The dispatcher never ran the callback (or the window is still up
+                // while the process is dying): dump the full report as the record.
+                Console.Error.WriteLine(ExceptionReport.Format(exception, DateTimeOffset.UtcNow, 1));
+            }
         }
         catch
         {

--- a/src/LincleLINK.App/Services/GlobalExceptionHandler.cs
+++ b/src/LincleLINK.App/Services/GlobalExceptionHandler.cs
@@ -204,6 +204,10 @@ public sealed class GlobalExceptionHandler : IExceptionReporter
         ThemeManager.ApplyTitleBar(window);
         vm.AttachWindow(window);
 
+        // Continue (and Esc, its IsCancel binding) ask the view model to close;
+        // close the window on CloseRequested, mirroring the DialogService pattern.
+        vm.CloseRequested += (_, _) => window.Close();
+
         window.Closed += (_, _) =>
         {
             // In fatal mode closing the window by any means (Quit, X, Esc) quits;

--- a/src/LincleLINK.App/Services/SemiLocale.cs
+++ b/src/LincleLINK.App/Services/SemiLocale.cs
@@ -1,0 +1,54 @@
+using System.Globalization;
+using Avalonia;
+using Semi.Avalonia;
+
+namespace LincleLINK.App.Services;
+
+/// <summary>
+/// Points Semi's built-in control strings (the TextBox context menu, etc.) at
+/// the Windows display language. Semi never reads the system culture: when
+/// <c>SemiTheme.Locale</c> is unset it stays on its Simplified-Chinese default,
+/// and its own lookup also falls back to zh-CN for unsupported cultures. The
+/// culture is therefore mapped onto Semi's shipped locale set here, with
+/// English as the final fallback. Must run before any window is created.
+/// </summary>
+public static class SemiLocale
+{
+    // The locale dictionaries shipped in Semi.Avalonia 12.1, representative
+    // culture first per language so the prefix match below picks it.
+    private static readonly string[] Supported =
+    [
+        "zh-CN", "zh-TW", "en-US", "en-GB", "ja-JP", "ko-KR", "de-DE", "es-ES",
+        "fr-FR", "it-IT", "it-CH", "nl-NL", "nl-BE", "pl-PL", "ru-RU", "uk-UA",
+    ];
+
+    public static void Apply(Application app)
+    {
+        // CurrentUICulture follows the Windows display language, not the
+        // regional/locale format settings.
+        var culture = Resolve(CultureInfo.CurrentUICulture);
+        foreach (var style in app.Styles)
+        {
+            if (style is SemiTheme theme)
+            {
+                theme.Locale = culture;
+            }
+        }
+    }
+
+    private static CultureInfo Resolve(CultureInfo ui)
+    {
+        var exact = Supported.FirstOrDefault(
+            n => string.Equals(n, ui.Name, StringComparison.OrdinalIgnoreCase));
+        if (exact is not null)
+        {
+            return new CultureInfo(exact);
+        }
+
+        // en-AU → en-US, ja → ja-JP, and so on; unknown languages get English.
+        var prefix = ui.TwoLetterISOLanguageName + "-";
+        var sameLanguage = Supported.FirstOrDefault(
+            n => n.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+        return new CultureInfo(sameLanguage ?? "en-US");
+    }
+}

--- a/src/LincleLINK.App/ViewModels/ExceptionReportViewModel.cs
+++ b/src/LincleLINK.App/ViewModels/ExceptionReportViewModel.cs
@@ -52,7 +52,7 @@ public partial class ExceptionReportViewModel : ViewModelBase
     public string DetailsText => _accumulator.BuildDetailsText();
 
     public string OverflowText => _accumulator.HasOverflow
-        ? $"…and {_accumulator.OverflowCount} more distinct errors"
+        ? ExceptionAccumulator.FormatOverflow(_accumulator.OverflowCount)
         : string.Empty;
 
     /// <summary>Same values that go into the copied Markdown report.</summary>

--- a/src/LincleLINK.App/ViewModels/ExceptionReportViewModel.cs
+++ b/src/LincleLINK.App/ViewModels/ExceptionReportViewModel.cs
@@ -1,0 +1,164 @@
+using System.Diagnostics;
+using System.Text;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input.Platform;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using LincleLINK.App.Services;
+using LincleLINK.App.ViewModels.Base;
+
+namespace LincleLINK.App.ViewModels;
+
+/// <summary>
+/// The error-report window (issue #16 D2): headline, summary card, full stack
+/// trace, environment strip and the Copy report / Open GitHub issues / Continue /
+/// Quit actions. One view model serves both the recoverable and the fatal modes
+/// (bound <see cref="IsFatal"/>); the storm guard lives in the underlying
+/// <see cref="ExceptionAccumulator"/>.
+/// </summary>
+public partial class ExceptionReportViewModel : ViewModelBase
+{
+    private readonly ExceptionAccumulator _accumulator;
+    private readonly Action _onQuit;
+    private Window? _hostWindow;
+
+    public override string Title { get; }
+
+    public override Size DialogSize => new(620, 480);
+
+    public override Size DialogMinSize => new(520, 380);
+
+    public bool IsFatal { get; }
+
+    public string Headline => IsFatal
+        ? "LincleLINK has to close"
+        : "LincleLINK ran into an unexpected error";
+
+    public string Helper => IsFatal
+        ? "An error stopped the app from starting. Copy the report below and attach it to a GitHub issue so this can be fixed."
+        : "You can keep using the app. If this keeps happening, please copy the report below and attach it to a GitHub issue.";
+
+    public string SummaryType => _accumulator.Primary?.GetType().FullName ?? string.Empty;
+
+    public string SummaryMessage => _accumulator.Primary?.Message ?? string.Empty;
+
+    /// <summary>Occurrence badge ("×7"), empty until the same error repeats.</summary>
+    public string OccurrencesText =>
+        _accumulator.PrimaryOccurrences > 1 ? $"×{_accumulator.PrimaryOccurrences}" : string.Empty;
+
+    public string DetailsText => _accumulator.BuildDetailsText();
+
+    public string OverflowText => _accumulator.HasOverflow
+        ? $"…and {_accumulator.OverflowCount} more distinct errors"
+        : string.Empty;
+
+    /// <summary>Same values that go into the copied Markdown report.</summary>
+    public string EnvironmentStrip => ExceptionReport.EnvironmentLine;
+
+    public bool NotFatal => !IsFatal;
+
+    public bool QuitIsDefault => IsFatal;
+
+    [ObservableProperty]
+    private string _copyButtonText = "Copy report";
+
+    public ExceptionReportViewModel(Exception exception, bool isFatal, Action onQuit)
+    {
+        _accumulator = new ExceptionAccumulator();
+        _accumulator.Add(exception);
+        _onQuit = onQuit;
+        IsFatal = isFatal;
+        Title = isFatal ? "LincleLINK could not start" : "Unexpected error - LincleLINK";
+    }
+
+    /// <summary>
+    /// The hosting window, used as the clipboard's top level (always available,
+    /// unlike the main window during startup failures).
+    /// </summary>
+    public void AttachWindow(Window window) => _hostWindow = window;
+
+    /// <summary>Registers another occurrence while the report window is open (D4).</summary>
+    public void AddException(Exception exception)
+    {
+        if (!_accumulator.Add(exception))
+        {
+            return;
+        }
+
+        OnPropertyChanged(nameof(SummaryType));
+        OnPropertyChanged(nameof(SummaryMessage));
+        OnPropertyChanged(nameof(OccurrencesText));
+        OnPropertyChanged(nameof(DetailsText));
+        OnPropertyChanged(nameof(OverflowText));
+    }
+
+    /// <summary>
+    /// The full Markdown report: the primary exception formatted by
+    /// <see cref="ExceptionReport"/>, an "Also occurred" section per additional
+    /// distinct exception, then the overflow line.
+    /// </summary>
+    public string BuildReportText()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(ExceptionReport.Format(
+            _accumulator.Primary!, DateTimeOffset.UtcNow, _accumulator.PrimaryOccurrences));
+
+        foreach (var extra in _accumulator.AdditionalExceptions())
+        {
+            sb.AppendLine();
+            sb.AppendLine("### Also occurred");
+            sb.AppendLine();
+            sb.AppendLine("```");
+            sb.AppendLine(extra.ToString());
+            sb.AppendLine("```");
+        }
+
+        if (_accumulator.HasOverflow)
+        {
+            sb.AppendLine();
+            sb.AppendLine(OverflowText);
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    [RelayCommand]
+    private async Task CopyReportAsync()
+    {
+        if (_hostWindow?.Clipboard is { } clipboard)
+        {
+            await clipboard.SetTextAsync(BuildReportText());
+            CopyButtonText = "Copied ✓";
+            await Task.Delay(2000);
+            CopyButtonText = "Copy report";
+        }
+    }
+
+    [RelayCommand]
+    private void OpenGitHubIssues()
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo("https://github.com/Radioo/LincleLINK/issues/new")
+            {
+                UseShellExecute = true,
+            });
+        }
+        catch (Exception ex)
+        {
+            // The report is still on screen and copyable; a broken launcher is not fatal.
+            Console.Error.WriteLine("Could not open the GitHub issues page: " + ex.Message);
+        }
+    }
+
+    [RelayCommand]
+    private void Continue() => RequestClose();
+
+    [RelayCommand]
+    private void Quit()
+    {
+        _onQuit();
+        RequestClose();
+    }
+}

--- a/src/LincleLINK.App/ViewModels/ExceptionReportViewModel.cs
+++ b/src/LincleLINK.App/ViewModels/ExceptionReportViewModel.cs
@@ -23,13 +23,15 @@ public partial class ExceptionReportViewModel : ViewModelBase
     private readonly Action _onQuit;
     private Window? _hostWindow;
 
-    public override string Title { get; }
+    public override string Title => _title;
+
+    private string _title;
 
     public override Size DialogSize => new(620, 480);
 
     public override Size DialogMinSize => new(520, 380);
 
-    public bool IsFatal { get; }
+    public bool IsFatal { get; private set; }
 
     public string Headline => IsFatal
         ? "LincleLINK has to close"
@@ -69,7 +71,7 @@ public partial class ExceptionReportViewModel : ViewModelBase
         _accumulator.Add(exception);
         _onQuit = onQuit;
         IsFatal = isFatal;
-        Title = isFatal ? "LincleLINK could not start" : "Unexpected error - LincleLINK";
+        _title = isFatal ? "LincleLINK could not start" : "Unexpected error - LincleLINK";
     }
 
     /// <summary>
@@ -77,6 +79,30 @@ public partial class ExceptionReportViewModel : ViewModelBase
     /// unlike the main window during startup failures).
     /// </summary>
     public void AttachWindow(Window window) => _hostWindow = window;
+
+    /// <summary>
+    /// Upgrades an open recoverable report to fatal mode when a fatal exception
+    /// arrives while it is showing (issue #16 D4): the headline, helper, buttons
+    /// and the quit-on-close behaviour all flip so the messaging matches the
+    /// process-dooming caller.
+    /// </summary>
+    public void MakeFatal()
+    {
+        if (IsFatal)
+        {
+            return;
+        }
+
+        IsFatal = true;
+        _title = "LincleLINK could not start";
+
+        OnPropertyChanged(nameof(IsFatal));
+        OnPropertyChanged(nameof(Title));
+        OnPropertyChanged(nameof(Headline));
+        OnPropertyChanged(nameof(Helper));
+        OnPropertyChanged(nameof(NotFatal));
+        OnPropertyChanged(nameof(QuitIsDefault));
+    }
 
     /// <summary>Registers another occurrence while the report window is open (D4).</summary>
     public void AddException(Exception exception)

--- a/src/LincleLINK.App/ViewModels/ExceptionReportViewModel.cs
+++ b/src/LincleLINK.App/ViewModels/ExceptionReportViewModel.cs
@@ -131,7 +131,6 @@ public partial class ExceptionReportViewModel : ViewModelBase
 
         foreach (var extra in _accumulator.AdditionalExceptions())
         {
-            sb.AppendLine();
             sb.AppendLine("### Also occurred");
             sb.AppendLine();
             sb.AppendLine("```");

--- a/src/LincleLINK.App/ViewModels/ExceptionReportViewModel.cs
+++ b/src/LincleLINK.App/ViewModels/ExceptionReportViewModel.cs
@@ -81,10 +81,9 @@ public partial class ExceptionReportViewModel : ViewModelBase
     /// <summary>Registers another occurrence while the report window is open (D4).</summary>
     public void AddException(Exception exception)
     {
-        if (!_accumulator.Add(exception))
-        {
-            return;
-        }
+        // Notify unconditionally: the overflow counter is displayed state, so even
+        // a dropped (over-the-cap) occurrence must refresh the overflow UI.
+        _accumulator.Add(exception);
 
         OnPropertyChanged(nameof(SummaryType));
         OnPropertyChanged(nameof(SummaryMessage));

--- a/src/LincleLINK.App/ViewModels/MainViewModel.cs
+++ b/src/LincleLINK.App/ViewModels/MainViewModel.cs
@@ -641,9 +641,12 @@ public partial class MainViewModel : ViewModelBase, IOperationHost
             // Expected environmental failures (locked file, permission denied,
             // full disk: IOException and its subclasses, UnauthorizedAccessException)
             // stay a one-line friendly dialog. Anything else is unexpected and gets
-            // the full crash-report window (issue #16 D5). Domain errors never reach
-            // here: they are returned via the operation result and already shown
-            // with ErrorAsync by the caller.
+            // the full crash-report window (issue #16 D5). IOException is a base
+            // class: subtypes like PathTooLongException and FileLoadException also
+            // match here, which is acceptable because they almost always surface
+            // from environmental conditions on a user-configured path. Domain errors
+            // never reach here: they are returned via the operation result and
+            // already shown with ErrorAsync by the caller.
             if (ex is IOException or UnauthorizedAccessException)
             {
                 await _dialogs.ErrorAsync(ex.Message, operationName);

--- a/src/LincleLINK.App/ViewModels/MainViewModel.cs
+++ b/src/LincleLINK.App/ViewModels/MainViewModel.cs
@@ -638,10 +638,20 @@ public partial class MainViewModel : ViewModelBase, IOperationHost
                 "Operation {Operation} failed after {ElapsedMs} ms",
                 operationName, stopwatch.ElapsedMilliseconds);
 
-            // Unexpected failures route to the report window (full stack trace)
-            // instead of a one-line message dialog (issue #16 D5). Expected /
-            // domain errors reported via the operation result keep ErrorAsync.
-            _exceptionReporter.ReportUnexpected(ex);
+            // Expected environmental failures (locked file, permission denied,
+            // full disk: IOException and its subclasses, UnauthorizedAccessException)
+            // stay a one-line friendly dialog. Anything else is unexpected and gets
+            // the full crash-report window (issue #16 D5). Domain errors never reach
+            // here: they are returned via the operation result and already shown
+            // with ErrorAsync by the caller.
+            if (ex is IOException or UnauthorizedAccessException)
+            {
+                await _dialogs.ErrorAsync(ex.Message, operationName);
+            }
+            else
+            {
+                _exceptionReporter.ReportUnexpected(ex);
+            }
         }
         finally
         {

--- a/src/LincleLINK.App/ViewModels/MainViewModel.cs
+++ b/src/LincleLINK.App/ViewModels/MainViewModel.cs
@@ -40,6 +40,7 @@ public partial class MainViewModel : ViewModelBase, IOperationHost
     private readonly DiagnosticLogOptions _logOptions;
     private readonly LogoCatalog _logoCatalog;
     private readonly IAppPaths _paths;
+    private readonly IExceptionReporter _exceptionReporter;
 
     /// <summary>Logo key → index in the built-in catalog, i.e. the supported-list order.</summary>
     private readonly Dictionary<string, int> _logoOrder;
@@ -323,7 +324,8 @@ public partial class MainViewModel : ViewModelBase, IOperationHost
         ILogger<MainViewModel> logger,
         DiagnosticLogOptions logOptions,
         LogoCatalog logoCatalog,
-        IAppPaths paths)
+        IAppPaths paths,
+        IExceptionReporter exceptionReporter)
     {
         _instanceService = instanceService;
         _linkingService = linkingService;
@@ -340,6 +342,7 @@ public partial class MainViewModel : ViewModelBase, IOperationHost
         _logOptions = logOptions;
         _logoCatalog = logoCatalog;
         _paths = paths;
+        _exceptionReporter = exceptionReporter;
 
         _logoOrder = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < logoCatalog.AllLogos.Count; i++)
@@ -634,7 +637,11 @@ public partial class MainViewModel : ViewModelBase, IOperationHost
                 ex,
                 "Operation {Operation} failed after {ElapsedMs} ms",
                 operationName, stopwatch.ElapsedMilliseconds);
-            await _dialogs.ErrorAsync(ex.Message, "Operation failed");
+
+            // Unexpected failures route to the report window (full stack trace)
+            // instead of a one-line message dialog (issue #16 D5). Expected /
+            // domain errors reported via the operation result keep ErrorAsync.
+            _exceptionReporter.ReportUnexpected(ex);
         }
         finally
         {

--- a/src/LincleLINK.App/Views/ExceptionReportView.axaml
+++ b/src/LincleLINK.App/Views/ExceptionReportView.axaml
@@ -45,14 +45,29 @@
         </Border>
 
         <!-- ═════ stack trace: read-only, selectable, fills the resizable area ═════ -->
-        <TextBox Grid.Row="2" x:Name="DetailsBox" Text="{Binding DetailsText, Mode=OneWay}"
+        <TextBox Grid.Row="2" x:Name="DetailsBox" Classes="CodeTrace"
+                 Text="{Binding DetailsText, Mode=OneWay}"
                  IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap"
                  FontFamily="Consolas, 'Cascadia Mono', monospace" FontSize="11"
                  VerticalAlignment="Stretch" VerticalContentAlignment="Top"
                  Background="{DynamicResource LLSurface}"
                  BorderBrush="{DynamicResource LLHairline}"
                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                 ScrollViewer.VerticalScrollBarVisibility="Auto" />
+                 ScrollViewer.VerticalScrollBarVisibility="Visible">
+            <!-- Semi's theme swaps the border background on :pointerover/:pressed,
+                 which flickers between the hover color and the normal one while
+                 drag-selecting. Re-assert the fixed brushes with a higher-specificity
+                 selector so the code surface stays constant (issue #16 D2). -->
+            <TextBox.Styles>
+                <Style Selector="TextBox.CodeTrace:pointerover /template/ Border#PART_ContentPresenterBorder">
+                    <Setter Property="Background" Value="{DynamicResource LLSurface}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource LLHairline}" />
+                </Style>
+                <Style Selector="TextBox.CodeTrace:pressed /template/ Border#PART_ContentPresenterBorder">
+                    <Setter Property="Background" Value="{DynamicResource LLSurface}" />
+                </Style>
+            </TextBox.Styles>
+        </TextBox>
 
         <!-- ═════ environment strip ═════ -->
         <Border Grid.Row="3" BorderBrush="{DynamicResource LLHairline}"

--- a/src/LincleLINK.App/Views/ExceptionReportView.axaml
+++ b/src/LincleLINK.App/Views/ExceptionReportView.axaml
@@ -47,12 +47,12 @@
         <!-- ═════ stack trace: read-only, selectable, fills the resizable area ═════ -->
         <TextBox Grid.Row="2" x:Name="DetailsBox" Classes="CodeTrace"
                  Text="{Binding DetailsText, Mode=OneWay}"
-                 IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap"
+                 IsReadOnly="True" AcceptsReturn="True" TextWrapping="NoWrap"
                  FontFamily="Consolas, 'Cascadia Mono', monospace" FontSize="11"
                  VerticalAlignment="Stretch" VerticalContentAlignment="Top"
                  Background="{DynamicResource LLSurface}"
                  BorderBrush="{DynamicResource LLHairline}"
-                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 ScrollViewer.HorizontalScrollBarVisibility="Auto"
                  ScrollViewer.VerticalScrollBarVisibility="Visible">
             <!-- Semi's theme swaps the border background on :pointerover/:pressed,
                  which flickers between the hover color and the normal one while

--- a/src/LincleLINK.App/Views/ExceptionReportView.axaml
+++ b/src/LincleLINK.App/Views/ExceptionReportView.axaml
@@ -45,9 +45,10 @@
         </Border>
 
         <!-- ═════ stack trace: read-only, selectable, fills the resizable area ═════ -->
-        <TextBox Grid.Row="2" Text="{Binding DetailsText, Mode=OneWay}"
+        <TextBox Grid.Row="2" x:Name="DetailsBox" Text="{Binding DetailsText, Mode=OneWay}"
                  IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap"
                  FontFamily="Consolas, 'Cascadia Mono', monospace" FontSize="11"
+                 VerticalAlignment="Stretch" VerticalContentAlignment="Top"
                  Background="{DynamicResource LLSurface}"
                  BorderBrush="{DynamicResource LLHairline}"
                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"

--- a/src/LincleLINK.App/Views/ExceptionReportView.axaml
+++ b/src/LincleLINK.App/Views/ExceptionReportView.axaml
@@ -66,6 +66,9 @@
                 <Style Selector="TextBox.CodeTrace:pressed /template/ Border#PART_ContentPresenterBorder">
                     <Setter Property="Background" Value="{DynamicResource LLSurface}" />
                 </Style>
+                <Style Selector="TextBox.CodeTrace:focus /template/ Border#PART_ContentPresenterBorder">
+                    <Setter Property="BorderBrush" Value="{DynamicResource LLHairline}" />
+                </Style>
             </TextBox.Styles>
         </TextBox>
 

--- a/src/LincleLINK.App/Views/ExceptionReportView.axaml
+++ b/src/LincleLINK.App/Views/ExceptionReportView.axaml
@@ -1,0 +1,82 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:LincleLINK.App.ViewModels"
+             x:Class="LincleLINK.App.Views.ExceptionReportView"
+             x:DataType="vm:ExceptionReportViewModel">
+    <Grid Margin="20" RowDefinitions="Auto,Auto,*,Auto,Auto" RowSpacing="14">
+
+        <!-- ═════ header: glyph + headline (issue #16 D2, variant A) ═════ -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="12">
+            <Border Width="40" Height="40" CornerRadius="20"
+                    Background="{DynamicResource LLDangerSoft}"
+                    VerticalAlignment="Center">
+                <TextBlock Text="!" FontSize="20" FontWeight="Bold"
+                           Foreground="{DynamicResource LLDanger}"
+                           HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Border>
+            <StackPanel Spacing="2" VerticalAlignment="Center" MaxWidth="520">
+                <TextBlock Text="{Binding Headline}" FontSize="15.5" FontWeight="SemiBold"
+                           TextWrapping="Wrap" />
+                <TextBlock Text="{Binding Helper}" FontSize="12.5" Opacity="0.7"
+                           TextWrapping="Wrap" />
+            </StackPanel>
+        </StackPanel>
+
+        <!-- ═════ summary card: danger rail + type/message/badge ═════ -->
+        <Border Grid.Row="1" Background="{DynamicResource LLCard}"
+                BorderBrush="{DynamicResource LLHairline}" BorderThickness="1"
+                CornerRadius="6">
+            <Grid ColumnDefinitions="3,*">
+                <Rectangle Grid.Column="0" Fill="{DynamicResource LLDanger}" />
+                <StackPanel Grid.Column="1" Margin="12,10" Spacing="2">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <SelectableTextBlock Text="{Binding SummaryType}"
+                                   FontFamily="Consolas, 'Cascadia Mono', monospace"
+                                   FontSize="12" Foreground="{DynamicResource LLDanger}"
+                                   TextWrapping="Wrap" />
+                        <TextBlock Text="{Binding OccurrencesText}" FontSize="12"
+                                   Foreground="{DynamicResource LLDanger}"
+                                   VerticalAlignment="Center" />
+                    </StackPanel>
+                    <SelectableTextBlock Text="{Binding SummaryMessage}" FontSize="13"
+                               TextWrapping="Wrap" />
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- ═════ stack trace: read-only, selectable, fills the resizable area ═════ -->
+        <TextBox Grid.Row="2" Text="{Binding DetailsText, Mode=OneWay}"
+                 IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap"
+                 FontFamily="Consolas, 'Cascadia Mono', monospace" FontSize="11"
+                 Background="{DynamicResource LLSurface}"
+                 BorderBrush="{DynamicResource LLHairline}"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto" />
+
+        <!-- ═════ environment strip ═════ -->
+        <Border Grid.Row="3" BorderBrush="{DynamicResource LLHairline}"
+                BorderThickness="0,1,0,0" Padding="0,8,0,0">
+            <TextBlock Text="{Binding EnvironmentStrip}" FontSize="11" Opacity="0.7" />
+        </Border>
+
+        <!-- ═════ actions ═════ -->
+        <StackPanel Grid.Row="4" Orientation="Horizontal"
+                    HorizontalAlignment="Right" Spacing="8">
+            <Button Content="{Binding CopyButtonText}" Classes="Primary" MinWidth="110"
+                    Command="{Binding CopyReportCommand}" />
+            <Button Content="Open GitHub issues…" Classes="Outline"
+                    Command="{Binding OpenGitHubIssuesCommand}" />
+            <Button Content="Continue" MinWidth="90" IsDefault="True" IsCancel="True"
+                    IsVisible="{Binding NotFatal}"
+                    Command="{Binding ContinueCommand}" />
+            <Button Content="Quit" Classes="Borderless" MinWidth="90"
+                    IsVisible="{Binding NotFatal}"
+                    Command="{Binding QuitCommand}" />
+            <Button Content="Quit" Classes="Danger Outline" MinWidth="90"
+                    IsDefault="{Binding QuitIsDefault}"
+                    IsVisible="{Binding IsFatal}"
+                    Command="{Binding QuitCommand}" />
+        </StackPanel>
+
+    </Grid>
+</UserControl>

--- a/src/LincleLINK.App/Views/ExceptionReportView.axaml
+++ b/src/LincleLINK.App/Views/ExceptionReportView.axaml
@@ -67,7 +67,7 @@
                     Command="{Binding CopyReportCommand}" />
             <Button Content="Open GitHub issues…" Classes="Outline"
                     Command="{Binding OpenGitHubIssuesCommand}" />
-            <Button Content="Continue" MinWidth="90" IsDefault="True" IsCancel="True"
+            <Button Content="Continue" MinWidth="90" IsDefault="{Binding NotFatal}" IsCancel="True"
                     IsVisible="{Binding NotFatal}"
                     Command="{Binding ContinueCommand}" />
             <Button Content="Quit" Classes="Borderless" MinWidth="90"

--- a/src/LincleLINK.App/Views/ExceptionReportView.axaml.cs
+++ b/src/LincleLINK.App/Views/ExceptionReportView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace LincleLINK.App.Views;
+
+public partial class ExceptionReportView : UserControl
+{
+    public ExceptionReportView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/LincleLINK.App/Views/MainWindow.axaml
+++ b/src/LincleLINK.App/Views/MainWindow.axaml
@@ -12,11 +12,15 @@
     <!-- Hidden until a DataContext exists: the first-run flow shows this window
          (as a dialog owner) before the view model can be constructed, and unbound
          page-visibility bindings would render every page stacked. -->
-    <Grid RowDefinitions="*,Auto"
+    <Grid RowDefinitions="Auto,*,Auto"
           IsVisible="{Binding $self.DataContext, Converter={x:Static ObjectConverters.IsNotNull}}">
 
-        <!-- ═════════ shell: sidebar | page area (plan 15 D1) ═════════ -->
-        <Panel Grid.Row="0">
+        <!-- DEBUG-only dev menu (issue #16 D6): populated from code-behind under
+             #if DEBUG so it is compiled out of Release builds entirely. -->
+        <Panel Grid.Row="0" x:Name="DevMenuHost" />
+
+        <!-- ═════ shell: sidebar | page area (plan 15 D1) ═════ -->
+        <Panel Grid.Row="1">
             <Grid ColumnDefinitions="200,*">
 
                 <views:Sidebar Grid.Column="0" />
@@ -45,6 +49,6 @@
         </Panel>
 
         <!-- ═════ activity bar (plan 15 D5) ═════ -->
-        <views:ActivityBar Grid.Row="1" />
+        <views:ActivityBar Grid.Row="2" />
     </Grid>
 </Window>

--- a/src/LincleLINK.App/Views/MainWindow.axaml.cs
+++ b/src/LincleLINK.App/Views/MainWindow.axaml.cs
@@ -9,6 +9,9 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+#if DEBUG
+        InitializeDevMenu();
+#endif
     }
 
     protected override void OnOpened(EventArgs e)
@@ -23,4 +26,53 @@ public partial class MainWindow : Window
             _ = viewModel.InitializeAsync();
         }
     }
+
+#if DEBUG
+    /// <summary>
+    /// DEBUG-only crash triggers (issue #16 D6): throw on demand from each
+    /// exception surface so the global handler can be exercised without UI
+    /// automation. Compiled out of Release builds entirely.
+    /// </summary>
+    private void InitializeDevMenu()
+    {
+        var debug = new MenuItem { Header = "Debug" };
+        debug.Items.Add(CreateThrowItem(
+            "Throw on the UI thread",
+            () => Throw(new InvalidOperationException("Deliberate UI-thread exception (dev menu)"))));
+        debug.Items.Add(CreateThrowItem(
+            "Throw in an un-awaited task",
+            () => _ = Task.Run(() => Throw(new InvalidOperationException("Deliberate unobserved task exception (dev menu)")))));
+        debug.Items.Add(CreateThrowItem(
+            "Throw on a raw background thread",
+            () =>
+            {
+                var thread = new Thread(() => Throw(new InvalidOperationException("Deliberate background-thread exception (dev menu)")));
+                thread.Start();
+            }));
+        debug.Items.Add(CreateThrowItem(
+            "Throw inside an operation",
+            () =>
+            {
+                if (DataContext is MainViewModel viewModel)
+                {
+                    // Exercises the RunOperationAsync catch-all routing (D5).
+                    _ = viewModel.RunOperationAsync("Dev throw", async _ =>
+                        throw new InvalidOperationException("Deliberate operation exception (dev menu)"));
+                }
+            }));
+
+        var menu = new Menu();
+        menu.Items.Add(debug);
+        DevMenuHost.Children.Add(menu);
+    }
+
+    private static MenuItem CreateThrowItem(string header, Action action)
+    {
+        var item = new MenuItem { Header = header };
+        item.Click += (_, _) => action();
+        return item;
+    }
+
+    private static void Throw(Exception exception) => throw exception;
+#endif
 }

--- a/tests/LincleLINK.App.Tests/DiagnosticLoggingTests.cs
+++ b/tests/LincleLINK.App.Tests/DiagnosticLoggingTests.cs
@@ -50,6 +50,7 @@ public sealed class DiagnosticLoggingTests
     private readonly IAppPaths _paths = Substitute.For<IAppPaths>();
     private readonly LogoCatalog _logoCatalog = new();
     private readonly IDialogService _dialogs = Substitute.For<IDialogService>();
+    private readonly IExceptionReporter _exceptionReporter = Substitute.For<IExceptionReporter>();
 
     private MainViewModel CreateViewModel(RecordingLoggerProvider provider, ISettingsStore settingsStore)
     {
@@ -70,7 +71,8 @@ public sealed class DiagnosticLoggingTests
             LoggerFactory.Create(builder => builder.AddProvider(provider).SetMinimumLevel(LogLevel.Debug)).CreateLogger<MainViewModel>(),
             Options,
             _logoCatalog,
-            _paths);
+            _paths,
+            _exceptionReporter);
     }
 
     private void StubStatus()
@@ -113,7 +115,8 @@ public sealed class DiagnosticLoggingTests
         var failure = provider.Logs.Single(l => l.Level == LogLevel.Error);
         failure.Exception.Should().BeSameAs(ex);
         failure.Scope.Should().Contain("Check unused");
-        await _dialogs.Received(1).ErrorAsync(ex.Message, "Operation failed");
+        _exceptionReporter.Received(1).ReportUnexpected(ex);
+        await _dialogs.DidNotReceive().ErrorAsync(Arg.Any<string>(), Arg.Any<string>());
     }
 
     [Fact]

--- a/tests/LincleLINK.App.Tests/DiagnosticLoggingTests.cs
+++ b/tests/LincleLINK.App.Tests/DiagnosticLoggingTests.cs
@@ -108,7 +108,7 @@ public sealed class DiagnosticLoggingTests
     {
         using var provider = new RecordingLoggerProvider();
         var vm = CreateViewModel(provider, Substitute.For<ISettingsStore>());
-        var ex = new IOException("boom");
+        var ex = new InvalidOperationException("boom");
 
         await vm.RunOperationAsync("Check unused", _ => throw ex);
 
@@ -117,6 +117,22 @@ public sealed class DiagnosticLoggingTests
         failure.Scope.Should().Contain("Check unused");
         _exceptionReporter.Received(1).ReportUnexpected(ex);
         await _dialogs.DidNotReceive().ErrorAsync(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task RunOperationAsync_logs_expected_failure_and_shows_friendly_dialog()
+    {
+        using var provider = new RecordingLoggerProvider();
+        var vm = CreateViewModel(provider, Substitute.For<ISettingsStore>());
+        var ex = new IOException("boom");
+
+        await vm.RunOperationAsync("Check unused", _ => throw ex);
+
+        var failure = provider.Logs.Single(l => l.Level == LogLevel.Error);
+        failure.Exception.Should().BeSameAs(ex);
+        failure.Scope.Should().Contain("Check unused");
+        await _dialogs.Received(1).ErrorAsync(ex.Message, "Check unused");
+        _exceptionReporter.DidNotReceive().ReportUnexpected(Arg.Any<Exception>());
     }
 
     [Fact]

--- a/tests/LincleLINK.App.Tests/MainViewModelCoverageTests.cs
+++ b/tests/LincleLINK.App.Tests/MainViewModelCoverageTests.cs
@@ -421,9 +421,17 @@ public sealed class MainViewModelCoverageTests : IDisposable
         vm.IsBusy.Should().BeFalse();
         provider.Logs.Should().Contain(l => l.Message.Contains("cancelled"));
 
-        var boom = new IOException("boom");
-        await vm.RunOperationAsync("Test op", _ => throw boom);
-        _exceptionReporter.Received(1).ReportUnexpected(boom);
+        var expected = new IOException("boom");
+        await vm.RunOperationAsync("Test op", _ => throw expected);
+        await _dialogs.Received(1).ErrorAsync(expected.Message, "Test op");
+        _exceptionReporter.DidNotReceive().ReportUnexpected(Arg.Any<Exception>());
+
+        _dialogs.ClearReceivedCalls();
+        _exceptionReporter.ClearReceivedCalls();
+
+        var unexpected = new InvalidOperationException("boom");
+        await vm.RunOperationAsync("Test op", _ => throw unexpected);
+        _exceptionReporter.Received(1).ReportUnexpected(unexpected);
         await _dialogs.DidNotReceive().ErrorAsync(Arg.Any<string>(), Arg.Any<string>());
         vm.IsBusy.Should().BeFalse();
     }

--- a/tests/LincleLINK.App.Tests/MainViewModelCoverageTests.cs
+++ b/tests/LincleLINK.App.Tests/MainViewModelCoverageTests.cs
@@ -46,6 +46,7 @@ public sealed class MainViewModelCoverageTests : IDisposable
     private readonly IGameVersionDetector _detector = Substitute.For<IGameVersionDetector>();
     private readonly LogoCatalog _logoCatalog = new();
     private readonly TempDir _temp = new();
+    private readonly IExceptionReporter _exceptionReporter = Substitute.For<IExceptionReporter>();
 
     public void Dispose() => _temp.Dispose();
 
@@ -67,7 +68,7 @@ public sealed class MainViewModelCoverageTests : IDisposable
             _dialogs, _taskbarProgress, _fs, _preflight, NullLogger<AddInstanceViewModel>.Instance, _detector),
         logger ?? NullLogger<MainViewModel>.Instance,
         new DiagnosticLogOptions(Path.Combine(_temp.Root, "logs")),
-        _logoCatalog, _paths);
+        _logoCatalog, _paths, _exceptionReporter);
     private void StubEmptyLibrary()
     {
         _repository.GetSummariesAsync(Arg.Any<CancellationToken>()).Returns([]);
@@ -420,8 +421,10 @@ public sealed class MainViewModelCoverageTests : IDisposable
         vm.IsBusy.Should().BeFalse();
         provider.Logs.Should().Contain(l => l.Message.Contains("cancelled"));
 
-        await vm.RunOperationAsync("Test op", _ => throw new IOException("boom"));
-        await _dialogs.Received(1).ErrorAsync("boom", "Operation failed");
+        var boom = new IOException("boom");
+        await vm.RunOperationAsync("Test op", _ => throw boom);
+        _exceptionReporter.Received(1).ReportUnexpected(boom);
+        await _dialogs.DidNotReceive().ErrorAsync(Arg.Any<string>(), Arg.Any<string>());
         vm.IsBusy.Should().BeFalse();
     }
 

--- a/tests/LincleLINK.App.Tests/MainViewModelTests.cs
+++ b/tests/LincleLINK.App.Tests/MainViewModelTests.cs
@@ -60,7 +60,8 @@ public sealed class MainViewModelTests
         logger ?? NullLogger<MainViewModel>.Instance,
         new DiagnosticLogOptions(Path.Combine(Path.GetTempPath(), "linclelink-testlogs", Guid.NewGuid().ToString("N"))),
         _logoCatalog,
-        _paths);
+        _paths,
+        Substitute.For<IExceptionReporter>());
 
     private void StubStatus(long dbSize = 0, long free = 1)
     {

--- a/tests/LincleLINK.App.Tests/Services/ExceptionAccumulatorTests.cs
+++ b/tests/LincleLINK.App.Tests/Services/ExceptionAccumulatorTests.cs
@@ -93,6 +93,28 @@ public sealed class ExceptionAccumulatorTests
     }
 
     [Fact]
+    public void BuildDetailsText_uses_singular_for_one_dropped_error()
+    {
+        var accumulator = new ExceptionAccumulator();
+        for (var i = 0; i < ExceptionAccumulator.MaxDistinctExceptions + 1; i++)
+        {
+            accumulator.Add(new InvalidOperationException($"error {i}"));
+        }
+
+        var text = accumulator.BuildDetailsText();
+
+        text.Should().Contain("…and 1 more distinct error");
+        text.Should().NotContain("…and 1 more distinct errors");
+    }
+
+    [Fact]
+    public void FormatOverflow_singular_for_one_and_plural_otherwise()
+    {
+        ExceptionAccumulator.FormatOverflow(1).Should().Be("…and 1 more distinct error");
+        ExceptionAccumulator.FormatOverflow(2).Should().Be("…and 2 more distinct errors");
+    }
+
+    [Fact]
     public void Reset_clears_items_and_overflow()
     {
         var accumulator = new ExceptionAccumulator();

--- a/tests/LincleLINK.App.Tests/Services/ExceptionAccumulatorTests.cs
+++ b/tests/LincleLINK.App.Tests/Services/ExceptionAccumulatorTests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+using LincleLINK.App.Services;
+using Xunit;
+
+namespace LincleLINK.App.Tests;
+
+/// <summary>
+/// Storm-guard coverage (issue #16 D4): dedupe by type + message + top stack
+/// frame, the distinct-exception cap and the overflow counter. Pure logic, no UI.
+/// </summary>
+public sealed class ExceptionAccumulatorTests
+{
+    [Fact]
+    public void Identical_exception_increments_primary_occurrences()
+    {
+        var accumulator = new ExceptionAccumulator();
+        var ex = new IOException("locked");
+
+        accumulator.Add(ex);
+        accumulator.Add(ex);
+
+        accumulator.Primary.Should().BeSameAs(ex);
+        accumulator.PrimaryOccurrences.Should().Be(2);
+        accumulator.DistinctCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Different_exceptions_accumulate_as_sections()
+    {
+        var accumulator = new ExceptionAccumulator();
+        accumulator.Add(new IOException("first"));
+        accumulator.Add(new NullReferenceException("second"));
+
+        accumulator.PrimaryOccurrences.Should().Be(1);
+        accumulator.DistinctCount.Should().Be(2);
+        accumulator.AdditionalExceptions().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Cap_limits_distinct_exceptions_and_tracks_overflow()
+    {
+        var accumulator = new ExceptionAccumulator();
+        for (var i = 0; i < ExceptionAccumulator.MaxDistinctExceptions + 3; i++)
+        {
+            accumulator.Add(new InvalidOperationException($"error {i}"));
+        }
+
+        accumulator.DistinctCount.Should().Be(ExceptionAccumulator.MaxDistinctExceptions);
+        accumulator.OverflowCount.Should().Be(3);
+        accumulator.HasOverflow.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Add_reports_whether_the_occurrence_was_dropped_for_the_cap()
+    {
+        var accumulator = new ExceptionAccumulator();
+        for (var i = 0; i < ExceptionAccumulator.MaxDistinctExceptions; i++)
+        {
+            accumulator.Add(new InvalidOperationException($"error {i}")).Should().BeTrue();
+        }
+
+        accumulator.Add(new InvalidOperationException("over the cap")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void BuildDetailsText_renders_primary_trace_and_separators()
+    {
+        var accumulator = new ExceptionAccumulator();
+        accumulator.Add(new IOException("first"));
+        accumulator.Add(new NullReferenceException("second"));
+
+        var text = accumulator.BuildDetailsText();
+
+        text.Should().Contain("System.IO.IOException: first");
+        text.Should().Contain("─ Also occurred ─");
+        text.Should().Contain("System.NullReferenceException: second");
+        text.Should().NotContain("more distinct errors");
+    }
+
+    [Fact]
+    public void BuildDetailsText_reports_overflow_when_capped()
+    {
+        var accumulator = new ExceptionAccumulator();
+        for (var i = 0; i < ExceptionAccumulator.MaxDistinctExceptions + 2; i++)
+        {
+            accumulator.Add(new InvalidOperationException($"error {i}"));
+        }
+
+        var text = accumulator.BuildDetailsText();
+
+        text.Should().Contain("…and 2 more distinct errors");
+        text.Should().Contain("10-exception cap");
+    }
+
+    [Fact]
+    public void Reset_clears_items_and_overflow()
+    {
+        var accumulator = new ExceptionAccumulator();
+        for (var i = 0; i < ExceptionAccumulator.MaxDistinctExceptions + 1; i++)
+        {
+            accumulator.Add(new InvalidOperationException($"error {i}"));
+        }
+
+        accumulator.Reset();
+
+        accumulator.DistinctCount.Should().Be(0);
+        accumulator.OverflowCount.Should().Be(0);
+        accumulator.HasOverflow.Should().BeFalse();
+        accumulator.Primary.Should().BeNull();
+    }
+
+    [Fact]
+    public void BuildKey_is_stable_and_carries_type_and_message()
+    {
+        var thrown = Capture(() => throw new InvalidOperationException("boom"));
+        var key = ExceptionAccumulator.BuildKey(thrown);
+
+        key.Should().Be(ExceptionAccumulator.BuildKey(thrown));
+        key.Should().Contain("System.InvalidOperationException");
+        key.Should().Contain("boom");
+        key.Should().Contain("BuildKey_is_stable_and_carries_type_and_message");
+    }
+
+    private static Exception Capture(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
+
+        throw new InvalidOperationException("action did not throw");
+    }
+}

--- a/tests/LincleLINK.App.Tests/Services/ExceptionReportTests.cs
+++ b/tests/LincleLINK.App.Tests/Services/ExceptionReportTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using LincleLINK.App.Services;
+using Xunit;
+
+namespace LincleLINK.App.Tests;
+
+public sealed class ExceptionReportTests
+{
+    private static readonly DateTimeOffset FixedUtc =
+        new(2026, 8, 5, 14, 3, 12, TimeSpan.Zero);
+
+    [Fact]
+    public void Format_includes_type_message_and_stack()
+    {
+        var text = ExceptionReport.Format(CreateException(), FixedUtc, 1);
+
+        text.Should().Contain("### Crash report");
+        text.Should().Contain("System.InvalidOperationException: boom");
+        text.Should().Contain("ExceptionReportTests.CreateException");
+    }
+
+    [Fact]
+    public void Format_renders_inner_exceptions()
+    {
+        var text = ExceptionReport.Format(CreateException(), FixedUtc, 1);
+
+        text.Should().Contain("System.IO.IOException: inner");
+    }
+
+    [Fact]
+    public void Format_includes_environment_lines()
+    {
+        var text = ExceptionReport.Format(new Exception("x"), FixedUtc, 1);
+
+        text.Should().MatchRegex(@"- \*\*Version:\*\* .+");
+        text.Should().MatchRegex(@"- \*\*OS:\*\* .+");
+        text.Should().Contain("- **Runtime:** .NET");
+        text.Should().Contain("· Avalonia ");
+    }
+
+    [Fact]
+    public void Format_writes_the_injected_timestamp_and_occurrences()
+    {
+        var text = ExceptionReport.Format(new Exception("x"), FixedUtc, 7);
+
+        text.Should().Contain("- **When (UTC):** 2026-08-05 14:03:12");
+        text.Should().Contain("- **Occurrences:** 7");
+    }
+
+    [Fact]
+    public void Format_is_deterministic_for_a_given_timestamp()
+    {
+        var first = ExceptionReport.Format(new Exception("x"), FixedUtc, 1);
+        var second = ExceptionReport.Format(new Exception("x"), FixedUtc, 1);
+
+        first.Should().Be(second);
+    }
+
+    [Fact]
+    public void Format_balances_code_fences()
+    {
+        var text = ExceptionReport.Format(CreateException(), FixedUtc, 1);
+
+        text.Count(c => c == '`').Should().Be(6);
+        text.Should().Contain("```");
+        text.TrimEnd().Should().EndWith("```");
+    }
+
+    [Fact]
+    public void Format_keeps_the_repro_prompt_placeholder()
+    {
+        var text = ExceptionReport.Format(new Exception("x"), FixedUtc, 1);
+
+        text.Should().Contain("**What I was doing:**");
+    }
+
+    [Fact]
+    public void EnvironmentLine_reports_app_os_runtime_and_avalonia()
+    {
+        ExceptionReport.EnvironmentLine.Should().StartWith("LincleLINK ");
+        ExceptionReport.EnvironmentLine.Should().Contain("· Avalonia ");
+        ExceptionReport.EnvironmentLine.Should().Contain(".NET");
+    }
+
+    private static Exception CreateException()
+    {
+        try
+        {
+            throw new InvalidOperationException("boom", new IOException("inner"));
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
+    }
+}

--- a/tests/LincleLINK.App.Tests/Services/ExceptionReportViewModelTests.cs
+++ b/tests/LincleLINK.App.Tests/Services/ExceptionReportViewModelTests.cs
@@ -147,7 +147,7 @@ public sealed class ExceptionReportViewModelTests
 
         changed.Should().Contain(nameof(vm.OverflowText));
         changed.Should().Contain(nameof(vm.DetailsText));
-        vm.OverflowText.Should().Be("…and 1 more distinct errors");
+        vm.OverflowText.Should().Be("…and 1 more distinct error");
     }
 
     private static ExceptionReportViewModel Create(bool isFatal, Exception? exception = null)

--- a/tests/LincleLINK.App.Tests/Services/ExceptionReportViewModelTests.cs
+++ b/tests/LincleLINK.App.Tests/Services/ExceptionReportViewModelTests.cs
@@ -86,6 +86,26 @@ public sealed class ExceptionReportViewModelTests
         report.Should().Contain("System.NullReferenceException: second");
     }
 
+    [Fact]
+    public void First_overflowed_exception_raises_overflow_property_changed()
+    {
+        var vm = Create(false, new InvalidOperationException("first"));
+        var changed = new List<string?>();
+        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        // Fill to the 10-exception cap: the initial one + 9 more.
+        for (var i = 0; i < ExceptionAccumulator.MaxDistinctExceptions - 1; i++)
+        {
+            vm.AddException(new InvalidOperationException($"error {i}"));
+        }
+
+        vm.AddException(new InvalidOperationException("over the cap"));
+
+        changed.Should().Contain(nameof(vm.OverflowText));
+        changed.Should().Contain(nameof(vm.DetailsText));
+        vm.OverflowText.Should().Be("…and 1 more distinct errors");
+    }
+
     private static ExceptionReportViewModel Create(bool isFatal, Exception? exception = null)
         => new(exception ?? new InvalidOperationException("boom"), isFatal, () => { });
 }

--- a/tests/LincleLINK.App.Tests/Services/ExceptionReportViewModelTests.cs
+++ b/tests/LincleLINK.App.Tests/Services/ExceptionReportViewModelTests.cs
@@ -50,6 +50,38 @@ public sealed class ExceptionReportViewModelTests
     }
 
     [Fact]
+    public void MakeFatal_flips_presentation_to_fatal()
+    {
+        var vm = Create(false);
+        var changed = new List<string?>();
+        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        vm.MakeFatal();
+
+        vm.IsFatal.Should().BeTrue();
+        vm.Title.Should().Be("LincleLINK could not start");
+        vm.Headline.Should().Be("LincleLINK has to close");
+        vm.Helper.Should().Contain("An error stopped the app from starting");
+        vm.NotFatal.Should().BeFalse();
+        vm.QuitIsDefault.Should().BeTrue();
+        changed.Should().Contain(nameof(vm.Headline));
+        changed.Should().Contain(nameof(vm.Helper));
+        changed.Should().Contain(nameof(vm.NotFatal));
+        changed.Should().Contain(nameof(vm.QuitIsDefault));
+    }
+
+    [Fact]
+    public void MakeFatal_is_a_no_op_when_already_fatal()
+    {
+        var vm = Create(true);
+
+        vm.MakeFatal();
+
+        vm.IsFatal.Should().BeTrue();
+        vm.Title.Should().Be("LincleLINK could not start");
+    }
+
+    [Fact]
     public void Summary_carries_type_and_message()
     {
         var vm = Create(false, new InvalidOperationException("boom"));

--- a/tests/LincleLINK.App.Tests/Services/ExceptionReportViewModelTests.cs
+++ b/tests/LincleLINK.App.Tests/Services/ExceptionReportViewModelTests.cs
@@ -38,6 +38,18 @@ public sealed class ExceptionReportViewModelTests
     }
 
     [Fact]
+    public void ContinueCommand_raises_CloseRequested()
+    {
+        var vm = Create(false);
+        var closed = false;
+        vm.CloseRequested += (_, _) => closed = true;
+
+        vm.ContinueCommand.Execute(null);
+
+        closed.Should().BeTrue();
+    }
+
+    [Fact]
     public void Summary_carries_type_and_message()
     {
         var vm = Create(false, new InvalidOperationException("boom"));

--- a/tests/LincleLINK.App.Tests/Services/ExceptionReportViewModelTests.cs
+++ b/tests/LincleLINK.App.Tests/Services/ExceptionReportViewModelTests.cs
@@ -1,0 +1,91 @@
+using FluentAssertions;
+using LincleLINK.App.Services;
+using LincleLINK.App.ViewModels;
+using Xunit;
+
+namespace LincleLINK.App.Tests;
+
+/// <summary>
+/// Report-window view model coverage (issue #16 D2): recoverable vs fatal mode,
+/// the occurrence badge, the overflow line, and the assembled copy report.
+/// </summary>
+public sealed class ExceptionReportViewModelTests
+{
+    [Fact]
+    public void Recoverable_mode_shows_continue_and_recoverable_copy()
+    {
+        var vm = Create(false);
+
+        vm.IsFatal.Should().BeFalse();
+        vm.Title.Should().Be("Unexpected error - LincleLINK");
+        vm.Headline.Should().Be("LincleLINK ran into an unexpected error");
+        vm.Helper.Should().Contain("You can keep using the app");
+        vm.NotFatal.Should().BeTrue();
+        vm.QuitIsDefault.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Fatal_mode_hides_continue_and_makes_quit_the_default()
+    {
+        var vm = Create(true);
+
+        vm.IsFatal.Should().BeTrue();
+        vm.Title.Should().Be("LincleLINK could not start");
+        vm.Headline.Should().Be("LincleLINK has to close");
+        vm.Helper.Should().Contain("An error stopped the app from starting");
+        vm.NotFatal.Should().BeFalse();
+        vm.QuitIsDefault.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Summary_carries_type_and_message()
+    {
+        var vm = Create(false, new InvalidOperationException("boom"));
+
+        vm.SummaryType.Should().Be("System.InvalidOperationException");
+        vm.SummaryMessage.Should().Be("boom");
+        vm.OccurrencesText.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Repeated_primary_exception_drives_the_occurrence_badge()
+    {
+        var vm = Create(false, new InvalidOperationException("boom"));
+
+        vm.AddException(new InvalidOperationException("boom"));
+        vm.AddException(new InvalidOperationException("boom"));
+
+        vm.OccurrencesText.Should().Be("×3");
+    }
+
+    [Fact]
+    public void Different_exceptions_append_sections_and_overflow()
+    {
+        var vm = Create(false, new InvalidOperationException("first"));
+
+        for (var i = 0; i < ExceptionAccumulator.MaxDistinctExceptions + 1; i++)
+        {
+            vm.AddException(new InvalidOperationException($"error {i}"));
+        }
+
+        vm.DetailsText.Should().Contain("─ Also occurred ─");
+        vm.OverflowText.Should().Be("…and 2 more distinct errors");
+    }
+
+    [Fact]
+    public void BuildReportText_contains_report_and_extra_sections()
+    {
+        var vm = Create(false, new InvalidOperationException("boom"));
+        vm.AddException(new NullReferenceException("second"));
+
+        var report = vm.BuildReportText();
+
+        report.Should().Contain("### Crash report");
+        report.Should().Contain("System.InvalidOperationException: boom");
+        report.Should().Contain("### Also occurred");
+        report.Should().Contain("System.NullReferenceException: second");
+    }
+
+    private static ExceptionReportViewModel Create(bool isFatal, Exception? exception = null)
+        => new(exception ?? new InvalidOperationException("boom"), isFatal, () => { });
+}

--- a/tests/LincleLINK.App.Views.Tests/ExceptionReportViewLayoutTests.cs
+++ b/tests/LincleLINK.App.Views.Tests/ExceptionReportViewLayoutTests.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using FluentAssertions;
 using LincleLINK.App.ViewModels;
 using LincleLINK.App.Views;
@@ -23,6 +24,27 @@ public sealed class ExceptionReportViewLayoutTests
 
             tallTrace.Should().BeGreaterThan(shortTrace + 60,
                 $"the trace should grow with the window (short={shortTrace}, tall={tallTrace})");
+        });
+    }
+
+    [Fact]
+    public void Trace_scrollbar_is_always_visible()
+    {
+        HeadlessAppHost.RunOnUiThread(() =>
+        {
+            var vm = new ExceptionReportViewModel(
+                new InvalidOperationException("boom"), isFatal: false, () => { });
+            var view = new ExceptionReportView { DataContext = vm };
+
+            var window = new Window { Content = view, Width = 620, Height = 480 };
+            window.Show();
+            var details = view.FindControl<TextBox>("DetailsBox")!;
+            var visibility = details.GetValue(ScrollViewer.VerticalScrollBarVisibilityProperty);
+            window.Close();
+
+            // A toggleable scrollbar changes the wrap width and makes the text
+            // jump lines while selecting; pin it visible (issue #16 D2).
+            visibility.Should().Be(ScrollBarVisibility.Visible);
         });
     }
 

--- a/tests/LincleLINK.App.Views.Tests/ExceptionReportViewLayoutTests.cs
+++ b/tests/LincleLINK.App.Views.Tests/ExceptionReportViewLayoutTests.cs
@@ -1,0 +1,41 @@
+using Avalonia.Controls;
+using FluentAssertions;
+using LincleLINK.App.ViewModels;
+using LincleLINK.App.Views;
+using Xunit;
+
+namespace LincleLINK.App.Views.Tests;
+
+/// <summary>
+/// Layout regression test for the report window (issue #16 D2): the stack-trace
+/// text box must grow with the window when it is resized vertically, not stay
+/// pinned to its content height (Semi's theme centers TextBoxes by default).
+/// </summary>
+public sealed class ExceptionReportViewLayoutTests
+{
+    [Fact]
+    public void Trace_area_fills_vertical_growth()
+    {
+        HeadlessAppHost.RunOnUiThread(() =>
+        {
+            var shortTrace = MeasureTraceHeight(480);
+            var tallTrace = MeasureTraceHeight(640);
+
+            tallTrace.Should().BeGreaterThan(shortTrace + 60,
+                $"the trace should grow with the window (short={shortTrace}, tall={tallTrace})");
+        });
+    }
+
+    private static double MeasureTraceHeight(double windowHeight)
+    {
+        var vm = new ExceptionReportViewModel(
+            new InvalidOperationException("boom"), isFatal: false, () => { });
+        var view = new ExceptionReportView { DataContext = vm };
+
+        var window = new Window { Content = view, Width = 620, Height = windowHeight };
+        window.Show();
+        var trace = view.FindControl<TextBox>("DetailsBox")!.Bounds.Height;
+        window.Close();
+        return trace;
+    }
+}

--- a/tests/LincleLINK.App.Views.Tests/InteractionTests.cs
+++ b/tests/LincleLINK.App.Views.Tests/InteractionTests.cs
@@ -293,6 +293,7 @@ public sealed class InteractionTests
             NullLogger<MainViewModel>.Instance,
             new DiagnosticLogOptions(Path.Combine(Path.GetTempPath(), "linclelink-view-logs", Guid.NewGuid().ToString("N"))),
             new LogoCatalog(),
-            paths);
+            paths,
+            Substitute.For<IExceptionReporter>());
     }
 }


### PR DESCRIPTION
#### Implements issue #16.

## Details:

### Surfaces covered (D1)
- **UI thread** (`Dispatcher.UIThread.UnhandledException`) - recoverable, `e.Handled = true`, report window shown, app keeps running.
- **Unobserved task faults** (`TaskScheduler.UnobservedTaskException`) - `SetObserved()`, marshaled to the UI thread (GC-timing dependent safety net).
- **Process-terminating throws** (`AppDomain.CurrentDomain.UnhandledException`) - best-effort fatal window, `Console.Error` fallback.
- Handler is installed at the top of `OnFrameworkInitializationCompleted`, before the composition root, so even bootstrap failures route through it. Never throws; `Console.Error` is the terminal fallback.

### Report window (D2)
- `ExceptionReportViewModel` + `ExceptionReportView` (Variant A from the attached design HTML), hosted in a resizable, centered window with themed title bar and app icon.
- Headline + friendly helper, summary card with danger rail (type + message selectable, `×N` occurrence badge), monospace read-only stack trace that stretches with the window, environment strip (version · OS · runtime · Avalonia), `Copy report` (clipboard, "Copied ✓" for 2s), `Open GitHub issues…`, `Continue` (recoverable, default) and `Quit`.
- Fatal mode: "LincleLINK has to close", Quit only (outlined danger, default), X/Esc quit.
- New `LLDangerSoft` token in both theme dictionaries; everything else uses existing `LL*` tokens.

### Report format (D3)
- `Services/ExceptionReport` - pure static Markdown formatter (version, OS, runtime, Avalonia, UTC timestamp, occurrence count, `What I was doing` repro prompt, fenced stack trace).

### Storm guard (D4)
- `Services/ExceptionAccumulator` - one window at a time, dedupe by type + message + top stack frame, max 10 distinct exceptions with "…and N more" overflow line.

### Integration (D5)
- Startup failures now show the fatal report window with the full stack trace (was a one-line `ErrorAsync`); `Console.Error` + `Shutdown(1)` contract preserved.
- `RunOperationAsync` catch-all routes unexpected failures to the report window instead of the message dialog (log line kept; `result.Error` domain paths keep `ErrorAsync`).

### Dev menu (D6)
- DEBUG-only `Debug` menu with on-demand throws: UI thread, un-awaited task, raw background thread, and inside an operation. Compiled out of Release.